### PR TITLE
Remove Admin Repr and add models

### DIFF
--- a/src/snap_saas_base/models/organization.py
+++ b/src/snap_saas_base/models/organization.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import sqlalchemy as sa
 import sqlalchemy.orm as so
 import uuid6
@@ -57,14 +55,6 @@ class Organization(AbstractModel):
     )
 
     __mapper_args__ = {"eager_defaults": True}
-
-    async def __admin_repr__(self, request: Any = None):
-        """Return the format a Organization will be shown in the interface."""
-        return f"{self.name}"
-
-    async def __admin_select2_repr__(self, request: Any = None) -> str:
-        """Return the format a Organization will be shown in a select."""
-        return f"<div><span>{self.name}</span></div>"
 
     @property
     def as_dict(self):

--- a/src/snap_saas_base/models/user.py
+++ b/src/snap_saas_base/models/user.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import sqlalchemy as sa
 import sqlalchemy.orm as so
 import uuid6
@@ -69,14 +67,6 @@ class User(AbstractModel):
     )
 
     __table_args__ = (sa.UniqueConstraint("username", "provider"),)
-
-    async def __admin_repr__(self, request: Any = None):
-        """Return the format a User will be shown in the interface."""
-        return f"{self.full_name} - {self.email}"
-
-    async def __admin_select2_repr__(self, request: Any = None) -> str:
-        """Return the format a User will be shown in a select."""
-        return f"<div><span>{self.full_name} - {self.email}</span></div>"
 
     @property
     def as_dict(self):

--- a/src/snap_saas_base/models/user.py
+++ b/src/snap_saas_base/models/user.py
@@ -76,7 +76,7 @@ class User(AbstractModel):
 
     async def __admin_select2_repr__(self, request: Any = None) -> str:
         """Return the format a User will be shown in a select."""
-        return "<div><span></span></div>"
+        return f"<div><span>{self.full_name} - {self.email}</span></div>"
 
     @property
     def as_dict(self):

--- a/src/snap_saas_base/models/workspace.py
+++ b/src/snap_saas_base/models/workspace.py
@@ -212,6 +212,10 @@ class WorkspaceApiKey(AbstractModel):
         The ID of the workspace the API key belongs to. This is a foreign key linked to the "workspaces" table.
     member_id : so.Mapped[str]
         The ID of the member associated with the API key. This is a foreign key linked to the "users" table.
+    workspace : so.Mapped["Workspace"]
+        an object representing the workspace the member belongs to
+    member : so.Mapped["User"]
+        an object representing the member of the workspace
     type : so.Mapped[str]
         The type of the API key.
     label : so.Mapped[str]
@@ -240,6 +244,8 @@ class WorkspaceApiKey(AbstractModel):
     member_id: so.Mapped[str] = so.mapped_column(
         sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
+    workspace: so.Mapped[Workspace] = so.relationship("Workspace", uselist=False, lazy="raise")
+    member: so.Mapped[User] = so.relationship("User", uselist=False, lazy="raise")
     type: so.Mapped[str] = so.mapped_column(nullable=False)
     label: so.Mapped[str] = so.mapped_column(nullable=False)
     key: so.Mapped[str] = so.mapped_column(nullable=False)

--- a/src/snap_saas_base/models/workspace.py
+++ b/src/snap_saas_base/models/workspace.py
@@ -53,14 +53,6 @@ class Workspace(AbstractModel):
 
     __table_args__ = (sa.UniqueConstraint("org_id", "slug"),)
 
-    async def __admin_repr__(self, request: Any = None):
-        """Return the format a Workspace will be shown in the interface."""
-        return f"{self.name}"
-
-    async def __admin_select2_repr__(self, request: Any = None) -> str:
-        """Return the format a Workspae will be shown in a select."""
-        return f"<div><span>{self.name}</span></div>"
-
     @property
     def as_dict(self):
         """Returns the workspace as a dictionary.


### PR DESCRIPTION
- Remove admin representation for models and select for all models. This function was passed to the front end.
- Add member and workspace Relationships to the model WorkspaceApiKey 